### PR TITLE
Use malloc instead of static arrays for memory.

### DIFF
--- a/defaults.mk
+++ b/defaults.mk
@@ -30,7 +30,7 @@ STRIP_CMD ?= strip --remove-section=.comment --remove-section=.note
 LIBS   ?= -lGL -lglut -lGLU -lX11 -lm -lpthread -lstdc++ -lXext -lXi -lxcb -lXau -lXdmcp -lgcc -lc
 CFLAGS += -I./ -I./src
 CFLAGS += "-DHERSHEY_FONTS_DIR=\"./\""
-CFLAGS += -ggdb -Wall -Wno-unknown-pragmas -O3
+CFLAGS += -ggdb -Wall -Wno-unknown-pragmas -O1
 CFLAGS += "-DTARGET=\"${TARGET}\""
 CFLAGS += "-DSYSTEM=\"${SYSTEM}\""
 CFLAGS += "-DMACHINE=\"${MACHINE}\""

--- a/src/dxf.h
+++ b/src/dxf.h
@@ -73,8 +73,10 @@ enum {
 	TYPE_LAST
 };
 
+/* TODO: is int really the right data type for an array index? update here and sizeof on realloc */
 typedef struct{
-	int line[MAX_LINES];
+	int *line;
+	int line_count;
 	int closed;
 	int inside;
 	int visited;

--- a/src/main.c
+++ b/src/main.c
@@ -2294,7 +2294,7 @@ void fill_objtree (void) {
 	int order_num = 0;
 	for (order_num = 0; order_num < object_last; order_num++) {
 		for (object_num = 0; object_num < object_last; object_num++) {
-			if (order_num == myOBJECTS[object_num].order && myOBJECTS[object_num].line[0] != 0) {
+			if (order_num == myOBJECTS[object_num].order && myOBJECTS[object_num].line_count) {
 				objtree_add_object(object_num);
 			}
 		}


### PR DESCRIPTION
This is the first step in being able to load larger DXF files.  With this
change, cammill only uses 0.5GB of RAM instead of 6.5GB on my machine
(dependant on dxf input).